### PR TITLE
Привел переменые balance, transfer к типу int64

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 func main() {
-	var balance int32 = 15_000_000_00
-	var transfer int32 = 10_000_000_00
-	total := int64(balance) + int64(transfer)
+	var balance uint32 = 15_000_000_00
+	var transfer uint32 = 10_000_000_00
+	total := uint64(balance) + uint64(transfer)
 	println(total)
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,6 @@ package main
 func main() {
 	var balance int32 = 15_000_000_00
 	var transfer int32 = 10_000_000_00
-	total := balance + transfer
+	total := int64(balance) + int64(transfer)
 	println(total)
 }


### PR DESCRIPTION
## Проблема заключается в переполнении переменных целочисленного типа int32
## Решение:
* Вариант 1.
Хранить переменные *balance* и *transfer* в **int** (с дефолтной разрядностью).
Но этот вариант может не подойти по причине экономии памяти. 
* Вариант 2.
При подсчете *total*, привести *balance* и *transfer* к типу **int64**, тогда переполнения переменной не произойдет.
* Вариант 3
В финансовой организации по бух. учету средства бываю дебетовыми и кредитовыми, отрицательное значение не принимают. Можно хранить переменные в **uint32**, для них столько же  выделиться памяти в 4 байта. Если у клиента будут храниться миллиарды в *total*, то эту переменную можно привести при подсчете к **uint64**
